### PR TITLE
Housekeeping fixes

### DIFF
--- a/lib/generators/templates/controllers/registrations_controller.rb
+++ b/lib/generators/templates/controllers/registrations_controller.rb
@@ -30,7 +30,7 @@ class RegistrationsController < ApplicationController
   private
 
   def setup_<%= identity_model %>
-    <%= identity_model_class %>.verify_signature!(TokenVerification::EMAIL_CONFIRMATION, params.require(:email_confirmation_token)) do |record, expires_at|
+    <%= identity_model_class %>.verify_signature!(Identity::EMAIL_CONFIRMATION_KEY, params.require(:email_confirmation_token)) do |record, expires_at|
       if expires_at < Time.current
         redirect_to(root_path, alert: t(:'auto_auth.registrations.expired'))
       else

--- a/lib/generators/templates/controllers/sessions_controller.rb
+++ b/lib/generators/templates/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
 
-  skip_before_action :authenticate!, only: :new
+  skip_before_action :authenticate!, only: [:new, :create]
   before_action :redirect_authenticated, only: [:new]
 
   def new

--- a/lib/generators/templates/models/identity_model.rb
+++ b/lib/generators/templates/models/identity_model.rb
@@ -17,7 +17,7 @@ class <%= identity_model_class %> < ActiveRecord::Base
   validates_confirmation_of :password, if: :password_required?
   validates_length_of :password, within: 8..128, allow_blank: true
 
-  before_save :downcase_email, -> { |ident| ident.email.downcase! }
+  before_save { |ident| ident.email.downcase! }
 
   def update_email(new_email)
     self.email = new_email


### PR DESCRIPTION
This fixes what broke for me tonight.  I'm happy to debate.  
- my example of the proc callback syntax is from here http://api.rubyonrails.org/classes/ActiveRecord/Callbacks.html
- TokenVerification::EMAIL_CONFIRMATION didn't exist
- I kept getting redirected to sessions#new when trying to run sessions#create

I like how this works! It solved most of my auth problems in an easy-to-understand way.
