### PR TITLE
Use less restrictive Rails dependency

### DIFF
--- a/auto_auth.gemspec
+++ b/auto_auth.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", "~> 4.1.8"
+  spec.add_dependency "rails", "~> 4"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sqlite3"


### PR DESCRIPTION
If you try to use this in a 4.2 project, it fails to bundle. I can't see this not working in any 4.x release. 

This PR opens up the gem for use in more 4.x projects.
