### PR TITLE
Substitute the name of the identity consistently

### DIFF
--- a/lib/generators/templates/controllers/registrations_controller.rb
+++ b/lib/generators/templates/controllers/registrations_controller.rb
@@ -4,7 +4,7 @@ class RegistrationsController < ApplicationController
 
   skip_before_action :authenticate!, only: [:new, :confirm, :create]
   before_action :redirect_authenticated, only: [:new, :create]
-  before_action :setup_identity, only: [:confirm]
+  before_action :setup_<%= identity_model %>, only: [:confirm]
 
   def new
     @registration = Registration.new
@@ -30,7 +30,7 @@ class RegistrationsController < ApplicationController
   private
 
   def setup_<%= identity_model %>
-    <%= identity_model_class %>.verify_signature!(Identity::EMAIL_CONFIRMATION_KEY, params.require(:email_confirmation_token)) do |record, expires_at|
+    <%= identity_model_class %>.verify_signature!(<%= identity_model_class %>::EMAIL_CONFIRMATION_KEY, params.require(:email_confirmation_token)) do |record, expires_at|
       if expires_at < Time.current
         redirect_to(root_path, alert: t(:'auto_auth.registrations.expired'))
       else

--- a/lib/generators/templates/controllers/sessions_controller.rb
+++ b/lib/generators/templates/controllers/sessions_controller.rb
@@ -7,9 +7,9 @@ class SessionsController < ApplicationController
   end
 
   def create
-    identity = <%= identity_model.classify %>.find_by(email: params[:session][:email])
-    if identity && identity.authenticate(params[:session].delete(:password))
-      session[:<%= "#{domain_model.underscore}_id" %>] = identity.<%= "#{domain_model.underscore}_id" %>
+    <%= identity_model %> = <%= identity_model.classify %>.find_by(email: params[:session][:email])
+    if <%= identity_model %> && <%= identity_model %>.authenticate(params[:session].delete(:password))
+      session[:<%= "#{domain_model.underscore}_id" %>] = <%= identity_model %>.<%= "#{domain_model.underscore}_id" %>
       redirect_to(after_sign_in_path, notice: t(:'auto_auth.sessions.signed_in'))
     else
       flash.now[:alert] = t(:'auto_auth.sessions.bad_combination')


### PR DESCRIPTION
The name of the identity-object is configurable. By default, it is just
Identity. If you pass an option to the generator, you can change it, to
say, Credential.

Failing to substitute this configurable name will cause references to
classes that don’t exist. If the identity-object is Credential, code
that refers to `Identity::CONST` will blow up.

To avoid code that says things like `identity = Credential.find(…)`,
make extra sure to substitute the correct name everywhere.
