### PR TITLE
Substitute name of the domain class consistently

### DIFF
--- a/lib/generators/templates/controllers/concerns/authentication.rb
+++ b/lib/generators/templates/controllers/concerns/authentication.rb
@@ -9,7 +9,7 @@ module Authentication
   end
 
   def sign_in!(<%= domain_model %>)
-    session[:user_id] = user.id
+    session[:<%= domain_model %>_id] = <%= domain_model %>.id
   end
 
   def current_<%= domain_model %>


### PR DESCRIPTION
The name of the domain-object is configurable. By default, it is just
User. If you pass an option to the generator, you can change it, to
say, Admin.
